### PR TITLE
Untitled

### DIFF
--- a/lib/request_log_analyzer/file_format.rb
+++ b/lib/request_log_analyzer/file_format.rb
@@ -10,6 +10,7 @@ module RequestLogAnalyzer::FileFormat
   autoload :Postgresql,       'request_log_analyzer/file_format/postgresql'
   autoload :DelayedJob,       'request_log_analyzer/file_format/delayed_job'
   autoload :DelayedJob2,      'request_log_analyzer/file_format/delayed_job2'
+  autoload :DelayedJob21,     'request_log_analyzer/file_format/delayed_job21'
   autoload :Apache,           'request_log_analyzer/file_format/apache'
   autoload :AmazonS3,         'request_log_analyzer/file_format/amazon_s3'
 

--- a/lib/request_log_analyzer/file_format/delayed_job21.rb
+++ b/lib/request_log_analyzer/file_format/delayed_job21.rb
@@ -1,14 +1,14 @@
 module RequestLogAnalyzer::FileFormat
 
-  # The DelayedJob2 file format parsed log files that are created by DelayedJob 2.0.
+  # The DelayedJob21 file format parsed log files that are created by DelayedJob 2.1 or higher.
   # By default, the log file can be found in RAILS_ROOT/log/delayed_job.log
-  class DelayedJob2 < Base
+  class DelayedJob21 < Base
     
     extend CommonRegularExpressions
     
     line_definition :job_lock do |line|
       line.header = true
-      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \* \[Worker\(\w+ host:(\S+) pid:(\d+)\)\] acquired lock on (\S+)/
+      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \[Worker\(\w+ host:(\S+) pid:(\d+)\)\] acquired lock on (\S+)/
       
       line.capture(:timestamp).as(:timestamp)
       line.capture(:host)
@@ -18,10 +18,11 @@ module RequestLogAnalyzer::FileFormat
     
     line_definition :job_completed do |line|
       line.footer = true
-      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \* \[JOB\] \w+ host:(\S+) pid:(\d+) completed after (\d+\.\d+)/
+      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \[Worker\(\w+ host:(\S+) pid:(\d+)\)\] (\S+) completed after (\d+\.\d+)/
       line.capture(:timestamp).as(:timestamp)
       line.capture(:host)
       line.capture(:pid).as(:integer)
+      line.capture(:job)
       line.capture(:duration).as(:duration, :unit => :sec)
     end
     

--- a/spec/unit/file_format/delayed_job21_format_spec.rb
+++ b/spec/unit/file_format/delayed_job21_format_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe RequestLogAnalyzer::FileFormat::DelayedJob do
+
+  it "should be a valid file format" do
+    RequestLogAnalyzer::FileFormat.load(:delayed_job).should be_valid
+  end
+
+  describe '#parse_line' do
+    
+    before(:each) do
+      @file_format = RequestLogAnalyzer::FileFormat.load(:delayed_job21)
+    end
+
+    it "should parse a :job_lock line correctly" do
+      line = "2010-05-17T17:37:34+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] acquired lock on S3FileJob"
+      @file_format.should parse_line(line).as(:job_lock).and_capture(:timestamp => 20100517173734,
+                                    :job => 'S3FileJob', :host => 'hostname.co.uk', :pid => 11888)
+    end
+
+    it "should parse a :job_completed line correctly" do
+      line = '2010-05-17T17:37:35+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] S3FileJob completed after 1.0676'
+      @file_format.should parse_line(line).as(:job_completed).and_capture(:timestamp => 20100517173735,
+                                    :duration => 1.0676, :host => 'hostname.co.uk', :pid => 11888, :job => 'S3FileJob')
+    end
+  end
+  
+  describe '#parse_io' do
+    before(:each) do
+      @log_parser = RequestLogAnalyzer::Source::LogParser.new(RequestLogAnalyzer::FileFormat.load(:delayed_job21))
+    end
+    
+    it "should parse a batch of completed jobs without warnings" do
+      fragment = <<-EOLOG
+        2010-05-17T17:36:44+0000: *** Starting job worker delayed_job host:hostname.co.uk pid:11888
+        2010-05-17T17:37:34+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] acquired lock on S3FileJob
+        2010-05-17T17:37:35+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] S3FileJob completed after 1.0676
+        2010-05-17T17:37:35+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] acquired lock on S3FileJob
+        2010-05-17T17:37:37+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] S3FileJob completed after 1.4407
+        2010-05-17T17:37:37+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] acquired lock on S3FileJob
+        2010-05-17T17:37:44+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] S3FileJob completed after 6.9374
+        2010-05-17T17:37:44+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] 3 jobs processed at 0.3163 j/s, 0 failed ...
+        2010-05-19T11:47:26+0000: Exiting...
+      EOLOG
+
+      request_counter.should_receive(:hit!).exactly(3).times
+      @log_parser.should_not_receive(:warn)
+
+      @log_parser.parse_io(StringIO.new(fragment)) do |request|
+        request_counter.hit! if request.kind_of?(RequestLogAnalyzer::FileFormat::DelayedJob21::Request)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey guys,

I'm using the 2.1.0pre version of delayed_job that is around for several months now. It introduces this nice .delay.method(params) syntax. But the log format has been changed with commit http://github.com/collectiveidea/delayed_job/commit/f3cf9603bf6656137cb24af557d82fbec58a97d1. That makes r-l-a not parsing the log anymore.
To not break existing installations of delayed_job 2.0 I introduced a new format delayed_job21. Imho it's more polite than changing the delayed_job2 one.

Greetings from Hamburg
Alexander
