### PR TITLE
Rails 3 format shouldn't fail in October, November or December

### DIFF
--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -89,7 +89,7 @@ module RequestLogAnalyzer::FileFormat
         time_as_str = value[-4..-1] # year
         # convert the month to a 2-digit representation
         month = MONTHS.index(value[3..5])+1
-        month < 10 ? time_as_str << "0#{month}" : time_as_str << month
+        month < 10 ? time_as_str << "0#{month}" : time_as_str << month.to_s
         
         time_as_str << value[6..13] # day of month + time
         time_as_str.to_i

--- a/spec/unit/file_format/rails3_format_spec.rb
+++ b/spec/unit/file_format/rails3_format_spec.rb
@@ -15,6 +15,12 @@ describe RequestLogAnalyzer::FileFormat::Rails do
             :path => '/queries', :ip => '127.0.0.1', :timestamp => 20100225161518)
     end
     
+    it "should parse :started lines in Oct, Nov and Dec correctly" do
+      line = 'Started GET "/queries" for 127.0.0.1 at Thu Oct 25 16:15:18 -0800 2010'
+      @file_format.should parse_line(line).as(:started).and_capture(:method => 'GET',
+            :path => '/queries', :ip => '127.0.0.1', :timestamp => 20101025161518)
+    end
+
     it "should parse :processing lines correctly" do
       line = ' Processing by QueriesController#index as HTML'
       @file_format.should parse_line(line).as(:processing).and_capture(


### PR DESCRIPTION
The timestamp parsing in the rails 3 format doesn't work when the month number is > 9 (on Ruby 1.8.7 at least).  This is because the month is appended to the timestamp as an integer rather than a string, i.e:

```
time_as_str << 10
```

Rather than:

```
time_as_str << "10"
```

This appends the character 10 to the string rather than the number, giving broken timestamp formats.
