### PR TITLE
Fix bug where "There were no requests analyzed." for delayed_job2 and delayed_job21 log files when running multiple workers

### DIFF
--- a/lib/request_log_analyzer/file_format/delayed_job2.rb
+++ b/lib/request_log_analyzer/file_format/delayed_job2.rb
@@ -8,7 +8,7 @@ module RequestLogAnalyzer::FileFormat
     
     line_definition :job_lock do |line|
       line.header = true
-      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \* \[Worker\(\w+ host:(\S+) pid:(\d+)\)\] acquired lock on (\S+)/
+      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \* \[Worker\(\S+ host:(\S+) pid:(\d+)\)\] acquired lock on (\S+)/
       
       line.capture(:timestamp).as(:timestamp)
       line.capture(:host)
@@ -18,7 +18,7 @@ module RequestLogAnalyzer::FileFormat
     
     line_definition :job_completed do |line|
       line.footer = true
-      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \* \[JOB\] \w+ host:(\S+) pid:(\d+) completed after (\d+\.\d+)/
+      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \* \[JOB\] \S+ host:(\S+) pid:(\d+) completed after (\d+\.\d+)/
       line.capture(:timestamp).as(:timestamp)
       line.capture(:host)
       line.capture(:pid).as(:integer)

--- a/lib/request_log_analyzer/file_format/delayed_job21.rb
+++ b/lib/request_log_analyzer/file_format/delayed_job21.rb
@@ -8,7 +8,7 @@ module RequestLogAnalyzer::FileFormat
     
     line_definition :job_lock do |line|
       line.header = true
-      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \[Worker\(\w+ host:(\S+) pid:(\d+)\)\] acquired lock on (\S+)/
+      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \[Worker\(\S+ host:(\S+) pid:(\d+)\)\] acquired lock on (\S+)/
       
       line.capture(:timestamp).as(:timestamp)
       line.capture(:host)
@@ -18,7 +18,7 @@ module RequestLogAnalyzer::FileFormat
     
     line_definition :job_completed do |line|
       line.footer = true
-      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \[Worker\(\w+ host:(\S+) pid:(\d+)\)\] (\S+) completed after (\d+\.\d+)/
+      line.regexp = /(#{timestamp('%Y-%m-%dT%H:%M:%S%z')}): \[Worker\(\S+ host:(\S+) pid:(\d+)\)\] (\S+) completed after (\d+\.\d+)/
       line.capture(:timestamp).as(:timestamp)
       line.capture(:host)
       line.capture(:pid).as(:integer)

--- a/spec/unit/file_format/delayed_job21_format_spec.rb
+++ b/spec/unit/file_format/delayed_job21_format_spec.rb
@@ -18,6 +18,12 @@ describe RequestLogAnalyzer::FileFormat::DelayedJob do
                                     :job => 'S3FileJob', :host => 'hostname.co.uk', :pid => 11888)
     end
 
+    it "should parse a :job_lock line correctly when the worker is one of many" do
+      line = "2010-05-17T17:37:34+0000: [Worker(delayed_job.0 host:hostname.co.uk pid:11888)] acquired lock on S3FileJob"
+      @file_format.should parse_line(line).as(:job_lock).and_capture(:timestamp => 20100517173734,
+                                    :job => 'S3FileJob', :host => 'hostname.co.uk', :pid => 11888)
+    end
+
     it "should parse a :job_completed line correctly" do
       line = '2010-05-17T17:37:35+0000: [Worker(delayed_job host:hostname.co.uk pid:11888)] S3FileJob completed after 1.0676'
       @file_format.should parse_line(line).as(:job_completed).and_capture(:timestamp => 20100517173735,

--- a/spec/unit/file_format/delayed_job2_format_spec.rb
+++ b/spec/unit/file_format/delayed_job2_format_spec.rb
@@ -18,6 +18,12 @@ describe RequestLogAnalyzer::FileFormat::DelayedJob do
                                     :job => 'S3FileJob', :host => 'hostname.co.uk', :pid => 11888)
     end
 
+    it "should parse a :job_lock line correctly when the worker is one of many" do
+      line = "2010-05-17T17:37:34+0000: * [Worker(delayed_job.0 host:hostname.co.uk pid:11888)] acquired lock on S3FileJob"
+      @file_format.should parse_line(line).as(:job_lock).and_capture(:timestamp => 20100517173734,
+                                    :job => 'S3FileJob', :host => 'hostname.co.uk', :pid => 11888)
+    end
+
     it "should parse a :job_completed line correctly" do
       line = '2010-05-17T17:37:35+0000: * [JOB] delayed_job host:hostname.co.uk pid:11888 completed after 1.0676'
       @file_format.should parse_line(line).as(:job_completed).and_capture(:timestamp => 20100517173735,


### PR DESCRIPTION
The regex was trying to match \w for the worker name, which could be delayed_job.0 or delayed_job.1

Changed \w to \S to fix. Tests included.
