### PR TITLE
Oink instance type counter

### DIFF
--- a/lib/request_log_analyzer/file_format/oink.rb
+++ b/lib/request_log_analyzer/file_format/oink.rb
@@ -85,7 +85,7 @@ class RequestLogAnalyzer::FileFormat::Oink < RequestLogAnalyzer::FileFormat::Rai
     count_strings = value.split(' | ')
     count_arrays = count_strings.map do |count_string|
       if count_string =~ /^(\w+): (\d+)/
-        [$1.downcase, $2.to_i]
+        [$1, $2.to_i]
       end
     end
 

--- a/spec/unit/file_format/oink_format_spec.rb
+++ b/spec/unit/file_format/oink_format_spec.rb
@@ -30,6 +30,13 @@ describe RequestLogAnalyzer::FileFormat::Oink do
       line = 'Aug 14 21:16:30 derek rails[67783]: Processing PeopleController#index (for 1.1.1.1 at 2008-08-14 21:16:30) [GET]'
       @oink.should parse_line(line).as(:processing).and_capture(:pid => 67783, :controller => 'PeopleController', :action => 'index', :timestamp => 20080814211630, :method => 'GET', :ip => '1.1.1.1')
     end
+
+    it "should parse a :instance_type_counter correctly" do
+
+      line = "Dec 13 12:00:44 storenvy rails[26364]: Instantiation Breakdown: Total: 732 | User: 376 | Post: 323 | Comment: 32 | Blog: 1"
+
+      @oink.should parse_line(line).as(:instance_type_counter).and_capture(:pid => 26364, :instance_counts =>  {'Total' => 732, 'User' => 376, 'Post' => 323, 'Comment' => 32, 'Blog' => 1})
+    end
   end
   
   describe '#parse_io' do


### PR DESCRIPTION
In addition to memory usage, Oink can log ActiveRecord instances created. Thought it would be rad to be able to parse this as well.

I have some crazy ideas for using request-log-analyzer to generate reports of leaky actions/requests, and this was just one step along the way :)
