### PR TITLE
pull request for haproxy log format support

### DIFF
--- a/lib/request_log_analyzer/file_format.rb
+++ b/lib/request_log_analyzer/file_format.rb
@@ -14,6 +14,7 @@ module RequestLogAnalyzer::FileFormat
   autoload :Apache,           'request_log_analyzer/file_format/apache'
   autoload :AmazonS3,         'request_log_analyzer/file_format/amazon_s3'
   autoload :W3c,              'request_log_analyzer/file_format/w3c'
+  autoload :Haproxy,          'request_log_analyzer/file_format/haproxy'
 
   # Loads a FileFormat::Base subclass instance.
   # You can provide:

--- a/lib/request_log_analyzer/file_format/haproxy.rb
+++ b/lib/request_log_analyzer/file_format/haproxy.rb
@@ -1,0 +1,138 @@
+module RequestLogAnalyzer::FileFormat
+
+  class Haproxy < RequestLogAnalyzer::FileFormat::Base
+
+    extend CommonRegularExpressions
+
+    # Define line types
+    line_definition :haproxy do |line|
+      line.header = true
+      line.footer = true
+
+      line.regexp = %r{
+        (#{ip_address}):\d+\s # client_ip ':' client_port
+        \[(#{timestamp('%d/%b/%Y:%H:%M:%S')})\.\d{3}\]\s # '[' accept_date ']'
+        (\S+)\s # frontend_name
+        (\S+)\/(\S+)\s # backend_name '/' server_name
+        (\d+|-1)\/(\d+|-1)\/(\d+|-1)\/(\d+|-1)\/\+?(\d+)\s # Tq '/' Tw '/' Tc '/' Tr '/' Tt
+        (\d+)\s # status_code
+        \+?(\d+)\s # bytes_read
+        (\S+)\s # captured_request_cookie
+        (\S+)\s # captured_response_cookie
+        (\w|-)(\w|-)(\w|-)(\w|-)\s # termination_state
+        (\d+)\/(\d+)\/(\d+)\/(\d+)\/\+?(\d+)\s # actconn '/' feconn '/' beconn '/' srv_conn '/' retries
+        (\d+)\/(\d+)\s # srv_queue '/' backend_queue
+        (\S*)\s? # captured_request_headers
+        (\S*)\s? # captured_response_headers
+        "([^"]*)" # '"' http_request '"'
+      }x
+
+      line.capture(:client_ip).as(:string)
+      line.capture(:accept_date).as(:timestamp)
+      line.capture(:frontend_name).as(:string)
+      line.capture(:backend_name).as(:string)
+      line.capture(:server_name).as(:string)
+      line.capture(:tq).as(:nillable_duration, :unit => :msec)
+      line.capture(:tw).as(:nillable_duration, :unit => :msec)
+      line.capture(:tc).as(:nillable_duration, :unit => :msec)
+      line.capture(:tr).as(:nillable_duration, :unit => :msec)
+      line.capture(:tt).as(:duration, :unit => :msec)
+      line.capture(:status_code).as(:integer)
+      line.capture(:bytes_read).as(:traffic, :unit => :byte)
+      line.capture(:captured_request_cookie).as(:nillable_string)
+      line.capture(:captured_response_cookie).as(:nillable_string)
+      line.capture(:termination_event_code).as(:nillable_string)
+      line.capture(:terminated_session_state).as(:nillable_string)
+      line.capture(:clientside_persistence_cookie).as(:nillable_string)
+      line.capture(:serverside_persistence_cookie).as(:nillable_string)
+      line.capture(:actconn).as(:integer)
+      line.capture(:feconn).as(:integer)
+      line.capture(:beconn).as(:integer)
+      line.capture(:srv_conn).as(:integer)
+      line.capture(:retries).as(:integer)
+      line.capture(:srv_queue).as(:integer)
+      line.capture(:backend_queue).as(:integer)
+      line.capture(:captured_request_headers).as(:nillable_string)
+      line.capture(:captured_response_headers).as(:nillable_string)
+      line.capture(:http_request).as(:nillable_string)
+    end
+
+    # Define the summary report
+    report do |analyze|
+      analyze.hourly_spread :field => :accept_date
+
+      analyze.frequency :client_ip,
+        :title => "Hits per IP"
+
+      analyze.frequency :frontend_name,
+        :title => "Hits per frontend service"
+
+      analyze.frequency :backend_name,
+        :title => "Hits per backend service"
+
+      analyze.frequency :server_name,
+        :title => "Hits per backend server"
+
+      analyze.frequency :status_code,
+        :title => "HTTP response code frequency"
+
+      analyze.frequency :http_request,
+        :title => "Most popular requests"
+
+      analyze.frequency :http_request,
+        :title => "Most frequent HTTP 40x errors",
+        :category => lambda { |r| "#{r[:http_request]}"},
+        :if => lambda { |r| r[:status_code] >= 400 and r[:status_code] <= 417 }
+
+      analyze.frequency :http_request,
+        :title => "Most frequent HTTP 50x errors",
+        :category => lambda { |r| "#{r[:http_request]}"},
+        :if => lambda { |r| r[:status_code] >= 500 and r[:status_code] <= 505 }
+
+      analyze.traffic :bytes_read,
+        :title => "Traffic per frontend service",
+        :category => lambda { |r| "#{r[:frontend_name]}"}
+
+      analyze.traffic :bytes_read,
+        :title => "Traffic per backend service",
+        :category => lambda { |r| "#{r[:backend_name]}"}
+
+      analyze.traffic :bytes_read,
+        :title => "Traffic per backend server",
+        :category => lambda { |r| "#{r[:server_name]}"}
+
+      analyze.duration :tr,
+        :title => "Time waiting for backend response",
+        :category => lambda { |r| "#{r[:http_request]}"}
+
+      analyze.duration :tt,
+        :title => "Total time spent on request",
+        :category => lambda { |r| "#{r[:http_request]}"}
+    end
+
+    # Define a custom Request class for the HAProxy file format to speed up
+    # timestamp handling. Shamelessly copied from apache.rb
+    class Request < RequestLogAnalyzer::Request
+
+      MONTHS = {'Jan' => '01', 'Feb' => '02', 'Mar' => '03', 'Apr' => '04', 'May' => '05', 'Jun' => '06',
+                'Jul' => '07', 'Aug' => '08', 'Sep' => '09', 'Oct' => '10', 'Nov' => '11', 'Dec' => '12' }
+
+      # Do not use DateTime.parse, but parse the timestamp ourselves to return
+      # a integer to speed up parsing.
+      def convert_timestamp(value, definition)
+        "#{value[7,4]}#{MONTHS[value[3,3]]}#{value[0,2]}#{value[12,2]}#{value[15,2]}#{value[18,2]}".to_i
+      end
+
+      # Make sure that the strings '-' or '{}' or '' are parsed as a nil value.
+      def convert_nillable_string(value, definition)
+        value =~ /-|\{\}|^$/ ? nil : value
+      end
+
+      # Make sure that -1 is parsed as a nil value.
+      def convert_nillable_duration(value, definition)
+        value == '-1' ? nil : convert_duration(value, definition)
+      end
+
+    end
+  end
+end

--- a/spec/unit/file_format/haproxy_format_spec.rb
+++ b/spec/unit/file_format/haproxy_format_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe RequestLogAnalyzer::FileFormat::Haproxy do
+
+  before(:each) do
+    @file_format = RequestLogAnalyzer::FileFormat.load(:haproxy)
+    @log_parser  = RequestLogAnalyzer::Source::LogParser.new(@file_format)
+    @sample1 = 'Feb  6 12:14:14 localhost haproxy[14389]: 10.0.1.2:33317 [06/Feb/2009:12:14:14.655] http-in static/srv1 10/0/30/69/109 200 2750 - - ---- 1/1/1/1/0 0/0 {1wt.eu} {} "GET /index.html HTTP/1.1"'
+    @sample2 = 'haproxy[18113]: 127.0.0.1:34549 [15/Oct/2003:15:19:06.103] px-http px-http/<NOSRV> -1/-1/-1/-1/+50001 408 +2750 - - cR-- 2/2/2/0/+2 0/0 ""'
+  end
+
+  it "should be a valid file format" do
+    @file_format.should be_valid
+  end
+
+  it "should parse access lines and capture all of its fields" do
+    @file_format.should have_line_definition(:haproxy).capturing(:client_ip, :accept_date, :frontend_name, :backend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :actconn, :feconn, :beconn, :srv_conn, :retries, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request)
+  end
+
+  it "should match the sample line" do
+    @file_format.parse_line(@sample1).should include(:line_definition, :captures)
+  end
+
+  it "should not match a nonsense line" do
+    @file_format.parse_line('dsadasdas dsaadsads dsaadsads').should be_nil
+  end
+
+  it "should parse and convert the sample fields correctly" do
+    @log_parser.parse_io(StringIO.new(@sample1)) do |request|
+      request[:client_ip].should                      == '10.0.1.2'
+      request[:accept_date].should                    == 20090206121414
+      request[:frontend_name].should                  == 'http-in'
+      request[:backend_name].should                   == 'static'
+      request[:server_name].should                    == 'srv1'
+      request[:tq].should                             == 0.010
+      request[:tw].should                             == 0.000
+      request[:tc].should                             == 0.030
+      request[:tr].should                             == 0.069
+      request[:tt].should                             == 0.109
+      request[:status_code].should                    == 200
+      request[:bytes_read].should                     == 2750
+      request[:captured_request_cookie].should        == nil
+      request[:captured_response_cookie].should       == nil
+      request[:termination_event_code].should         == nil
+      request[:terminated_session_state].should       == nil
+      request[:clientside_persistence_cookie].should  == nil
+      request[:serverside_persistence_cookie].should  == nil
+      request[:actconn].should                        == 1
+      request[:feconn].should                         == 1
+      request[:beconn].should                         == 1
+      request[:srv_conn].should                       == 1
+      request[:retries].should                        == 0
+      request[:srv_queue].should                      == 0
+      request[:backend_queue].should                  == 0
+      request[:captured_request_headers].should       == '{1wt.eu}'
+      request[:captured_response_headers].should      == nil
+      request[:http_request].should                   == 'GET /index.html HTTP/1.1'
+    end
+  end
+
+  it "should parse and convert edge case sample fields correctly" do
+    @log_parser.parse_io(StringIO.new(@sample2)) do |request|
+      request[:accept_date].should                    == 20031015151906
+      request[:server_name].should                    == '<NOSRV>'
+      request[:tq].should                             == nil
+      request[:tw].should                             == nil
+      request[:tc].should                             == nil
+      request[:tr].should                             == nil
+      request[:tt].should                             == 50.001
+      request[:bytes_read].should                     == 2750
+      request[:captured_request_cookie].should        == nil
+      request[:captured_response_cookie].should       == nil
+      request[:termination_event_code].should         == 'c'
+      request[:terminated_session_state].should       == 'R'
+      request[:clientside_persistence_cookie].should  == nil
+      request[:serverside_persistence_cookie].should  == nil
+      request[:retries].should                        == 2
+      request[:captured_request_headers].should       == nil
+      request[:captured_response_headers].should      == nil
+      request[:http_request].should                   == nil
+    end
+  end
+
+end


### PR DESCRIPTION
Hello,

I've been using request-log-analyzer to parse logs from my HAProxy frontend for a few weeks now. I've been able to extract a lot of valuable informations from this 1 million lines per day logfile I have to deal with. This tool is very well thougth. It was almost trivial to add support for HAProxy's log format. Many thanks !

To come to the point: I would be honored to contribute this modest feature to your project :-)

Cheers,
Marc
