### PR TITLE
This fixes #97

### DIFF
--- a/lib/request_log_analyzer/file_format/haproxy.rb
+++ b/lib/request_log_analyzer/file_format/haproxy.rb
@@ -4,28 +4,42 @@ module RequestLogAnalyzer::FileFormat
 
     extend CommonRegularExpressions
 
-    # Define line types
-    line_definition :access do |line|
-      line.header = true
-      line.footer = true
-
-      line.regexp = %r{
+    # substitute version specific parts of the haproxy entry regexp.
+    def self.compose_regexp(millisecs, backends, counters, connections, queues)
+      %r{
         (#{ip_address}):\d+\s # client_ip ':' client_port
-        \[(#{timestamp('%d/%b/%Y:%H:%M:%S')})\.\d{3}\]\s # '[' accept_date ']'
+        \[(#{timestamp('%d/%b/%Y:%H:%M:%S')})#{millisecs}\]\s # '[' accept_date ']'
         (\S+)\s # frontend_name
-        (\S+)\/(\S+)\s # backend_name '/' server_name
-        (\d+|-1)\/(\d+|-1)\/(\d+|-1)\/(\d+|-1)\/\+?(\d+)\s # Tq '/' Tw '/' Tc '/' Tr '/' Tt
+        #{backends}
+        #{counters}
         (\d+)\s # status_code
         \+?(\d+)\s # bytes_read
         (\S+)\s # captured_request_cookie
         (\S+)\s # captured_response_cookie
         (\w|-)(\w|-)(\w|-)(\w|-)\s # termination_state
-        (\d+)\/(\d+)\/(\d+)\/(\d+)\/\+?(\d+)\s # actconn '/' feconn '/' beconn '/' srv_conn '/' retries
-        (\d+)\/(\d+)\s # srv_queue '/' backend_queue
+        #{connections}
+        #{queues}
         (\S*)\s? # captured_request_headers
         (\S*)\s? # captured_response_headers
         "([^"]*)" # '"' http_request '"'
       }x
+    end
+
+    # Define line types
+
+    # line definition for haproxy 1.3 and higher
+    line_definition :haproxy13 do |line|
+      line.header = true
+      line.footer = true
+      line.teaser = /\.\d{3}\] \S+ \S+\/\S+ / # .millisecs] frontend_name backend_name/server_name
+
+      line.regexp = compose_regexp(
+        '\.\d{3}', # millisecs
+        '(\S+)\/(\S+)\s', # backend_name '/' server_name
+        '(\d+|-1)\/(\d+|-1)\/(\d+|-1)\/(\d+|-1)\/\+?(\d+)\s', # Tq '/' Tw '/' Tc '/' Tr '/' Tt
+        '(\d+)\/(\d+)\/(\d+)\/(\d+)\/\+?(\d+)\s', # actconn '/' feconn '/' beconn '/' srv_conn '/' retries
+        '(\d+)\/(\d+)\s' # srv_queue '/' backend_queue
+      )
 
       line.capture(:client_ip).as(:string)
       line.capture(:timestamp).as(:timestamp)
@@ -50,6 +64,86 @@ module RequestLogAnalyzer::FileFormat
       line.capture(:beconn).as(:integer)
       line.capture(:srv_conn).as(:integer)
       line.capture(:retries).as(:integer)
+      line.capture(:srv_queue).as(:integer)
+      line.capture(:backend_queue).as(:integer)
+      line.capture(:captured_request_headers).as(:nillable_string)
+      line.capture(:captured_response_headers).as(:nillable_string)
+      line.capture(:http_request).as(:nillable_string)
+    end
+
+    # haproxy 1.2 has a few fields less than 1.3+
+    line_definition :haproxy12 do |line|
+      line.header = true
+      line.footer = true
+      line.teaser = /\.\d{3}\] \S+ \S+ / # .millisecs] frontend_name server_name
+
+      line.regexp = compose_regexp(
+        '\.\d{3}', # millisecs
+        '(\S+)\s', # server_name
+        '(\d+|-1)\/(\d+|-1)\/(\d+|-1)\/(\d+|-1)\/\+?(\d+)\s', # Tq '/' Tw '/' Tc '/' Tr '/' Tt
+        '(\d+)\/(\d+)\/(\d+)\s', # srv_conn '/' listener_conn '/' process_conn
+        '(\d+)\/(\d+)\s' # srv_queue '/' backend_queue
+      )
+
+      line.capture(:client_ip).as(:string)
+      line.capture(:timestamp).as(:timestamp)
+      line.capture(:frontend_name).as(:string)
+      line.capture(:server_name).as(:string)
+      line.capture(:tq).as(:nillable_duration, :unit => :msec)
+      line.capture(:tw).as(:nillable_duration, :unit => :msec)
+      line.capture(:tc).as(:nillable_duration, :unit => :msec)
+      line.capture(:tr).as(:nillable_duration, :unit => :msec)
+      line.capture(:tt).as(:duration, :unit => :msec)
+      line.capture(:status_code).as(:integer)
+      line.capture(:bytes_read).as(:traffic, :unit => :byte)
+      line.capture(:captured_request_cookie).as(:nillable_string)
+      line.capture(:captured_response_cookie).as(:nillable_string)
+      line.capture(:termination_event_code).as(:nillable_string)
+      line.capture(:terminated_session_state).as(:nillable_string)
+      line.capture(:clientside_persistence_cookie).as(:nillable_string)
+      line.capture(:serverside_persistence_cookie).as(:nillable_string)
+      line.capture(:srv_conn).as(:integer)
+      line.capture(:listener_conn).as(:integer)
+      line.capture(:process_conn).as(:integer)
+      line.capture(:srv_queue).as(:integer)
+      line.capture(:backend_queue).as(:integer)
+      line.capture(:captured_request_headers).as(:nillable_string)
+      line.capture(:captured_response_headers).as(:nillable_string)
+      line.capture(:http_request).as(:nillable_string)
+    end
+
+    # and haproxy 1.1 has even less fields
+    line_definition :haproxy11 do |line|
+      line.header = true
+      line.footer = true
+      line.teaser = /:\d{2}\] \S+ \S+ / # :secs] frontend_name server_name
+
+      line.regexp = compose_regexp(
+        '', # no millisec precision in this version of haproxy
+        '(\S+)\s', # server_name
+        '(\d+|-1)\/(\d+|-1)\/(\d+|-1)\/\+?(\d+)\s', # Tq '/' Tc '/' Tr '/' Tt
+        '(\d+)\/(\d+)\s', # listener_conn '/' process_conn
+        '' # no queues in this version of haproxy
+      )
+
+      line.capture(:client_ip).as(:string)
+      line.capture(:timestamp).as(:timestamp)
+      line.capture(:frontend_name).as(:string)
+      line.capture(:server_name).as(:string)
+      line.capture(:tq).as(:nillable_duration, :unit => :msec)
+      line.capture(:tc).as(:nillable_duration, :unit => :msec)
+      line.capture(:tr).as(:nillable_duration, :unit => :msec)
+      line.capture(:tt).as(:duration, :unit => :msec)
+      line.capture(:status_code).as(:integer)
+      line.capture(:bytes_read).as(:traffic, :unit => :byte)
+      line.capture(:captured_request_cookie).as(:nillable_string)
+      line.capture(:captured_response_cookie).as(:nillable_string)
+      line.capture(:termination_event_code).as(:nillable_string)
+      line.capture(:terminated_session_state).as(:nillable_string)
+      line.capture(:clientside_persistence_cookie).as(:nillable_string)
+      line.capture(:serverside_persistence_cookie).as(:nillable_string)
+      line.capture(:listener_conn).as(:integer)
+      line.capture(:process_conn).as(:integer)
       line.capture(:srv_queue).as(:integer)
       line.capture(:backend_queue).as(:integer)
       line.capture(:captured_request_headers).as(:nillable_string)

--- a/lib/request_log_analyzer/file_format/haproxy.rb
+++ b/lib/request_log_analyzer/file_format/haproxy.rb
@@ -42,7 +42,7 @@ module RequestLogAnalyzer::FileFormat
       )
 
       line.capture(:client_ip).as(:string)
-      line.capture(:timestamp).as(:timestamp)
+      line.capture(:accept_date).as(:timestamp)
       line.capture(:frontend_name).as(:string)
       line.capture(:backend_name).as(:string)
       line.capture(:server_name).as(:string)
@@ -86,7 +86,7 @@ module RequestLogAnalyzer::FileFormat
       )
 
       line.capture(:client_ip).as(:string)
-      line.capture(:timestamp).as(:timestamp)
+      line.capture(:accept_date).as(:timestamp)
       line.capture(:frontend_name).as(:string)
       line.capture(:server_name).as(:string)
       line.capture(:tq).as(:nillable_duration, :unit => :msec)
@@ -127,7 +127,7 @@ module RequestLogAnalyzer::FileFormat
       )
 
       line.capture(:client_ip).as(:string)
-      line.capture(:timestamp).as(:timestamp)
+      line.capture(:accept_date).as(:timestamp)
       line.capture(:frontend_name).as(:string)
       line.capture(:server_name).as(:string)
       line.capture(:tq).as(:nillable_duration, :unit => :msec)
@@ -153,7 +153,7 @@ module RequestLogAnalyzer::FileFormat
 
     # Define the summary report
     report do |analyze|
-      analyze.hourly_spread :field => :timestamp
+      analyze.hourly_spread :field => :accept_date
 
       analyze.frequency :client_ip,
         :title => "Hits per IP"

--- a/spec/unit/file_format/haproxy_format_spec.rb
+++ b/spec/unit/file_format/haproxy_format_spec.rb
@@ -7,9 +7,9 @@ describe RequestLogAnalyzer::FileFormat::Haproxy do
 
   it { should be_well_formed }
 
-  it { should have_line_definition(:haproxy13).capturing(:client_ip, :timestamp, :frontend_name, :backend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :actconn, :feconn, :beconn, :srv_conn, :retries, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request) }
-  it { should have_line_definition(:haproxy12).capturing(:client_ip, :timestamp, :frontend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :srv_conn, :listener_conn, :process_conn, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request) }
-  it { should have_line_definition(:haproxy11).capturing(:client_ip, :timestamp, :frontend_name, :server_name, :tq, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :listener_conn, :process_conn, :captured_request_headers, :captured_response_headers, :http_request) }
+  it { should have_line_definition(:haproxy13).capturing(:client_ip, :accept_date, :frontend_name, :backend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :actconn, :feconn, :beconn, :srv_conn, :retries, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request) }
+  it { should have_line_definition(:haproxy12).capturing(:client_ip, :accept_date, :frontend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :srv_conn, :listener_conn, :process_conn, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request) }
+  it { should have_line_definition(:haproxy11).capturing(:client_ip, :accept_date, :frontend_name, :server_name, :tq, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :listener_conn, :process_conn, :captured_request_headers, :captured_response_headers, :http_request) }
 
   it { should have(14).report_trackers }
 
@@ -20,33 +20,33 @@ describe RequestLogAnalyzer::FileFormat::Haproxy do
 
   describe '#parse_line' do
     it { should parse_line(sample_haproxy13, 'an haproxy 1.3 access line').and_capture(
-            :client_ip => '10.0.1.2',     :tq => 0.010,   :captured_request_cookie => nil,
-            :timestamp => 20090206121414, :tw => 0.000,   :captured_response_cookie => nil,
-            :frontend_name => 'http-in',  :tc => 0.030,   :clientside_persistence_cookie => nil,
-            :backend_name => 'static',    :tr => 0.069,   :serverside_persistence_cookie => nil,
-            :server_name => 'srv1',       :tt => 0.109,   :termination_event_code => nil,
-            :status_code => 200,          :actconn => 1,  :terminated_session_state => nil,
-            :bytes_read => 2750,          :feconn => 1,   :captured_request_headers => '{1wt.eu}',
-            :backend_queue => 0,          :beconn => 1,   :captured_response_headers => nil,
-            :retries => 0,                :srv_conn => 1, :srv_queue => 0,
+            :client_ip => '10.0.1.2',       :tq => 0.010,   :captured_request_cookie => nil,
+            :accept_date => 20090206121414, :tw => 0.000,   :captured_response_cookie => nil,
+            :frontend_name => 'http-in',    :tc => 0.030,   :clientside_persistence_cookie => nil,
+            :backend_name => 'static',      :tr => 0.069,   :serverside_persistence_cookie => nil,
+            :server_name => 'srv1',         :tt => 0.109,   :termination_event_code => nil,
+            :status_code => 200,            :actconn => 1,  :terminated_session_state => nil,
+            :bytes_read => 2750,            :feconn => 1,   :captured_request_headers => '{1wt.eu}',
+            :backend_queue => 0,            :beconn => 1,   :captured_response_headers => nil,
+            :retries => 0,                  :srv_conn => 1, :srv_queue => 0,
             :http_request => 'GET /index.html HTTP/1.1')
     }
 
     it { should parse_line(sample_haproxy12, 'an haproxy 1.2 access line').and_capture(
-            :client_ip => '127.0.0.1',    :tq => 0.000,         :captured_request_cookie => nil,
-            :timestamp => 20110315063645, :tw => 0.000,         :captured_response_cookie => nil,
-            :frontend_name => 'as-proxy', :tc => 0.000,         :clientside_persistence_cookie => 'N',
-            :server_name => 'mc-search-2',:tr => 0.730,         :serverside_persistence_cookie => 'N',
-            :status_code => 200,          :tt => 0.731,         :termination_event_code => nil,
-            :bytes_read => 29404,         :listener_conn => 54, :terminated_session_state => nil,
-            :backend_queue => 0,          :process_conn => 54,  :captured_request_headers => '{66.249.68.216}',
-            :srv_queue => 0,              :srv_conn => 2,       :captured_response_headers => nil,
+            :client_ip => '127.0.0.1',      :tq => 0.000,         :captured_request_cookie => nil,
+            :accept_date => 20110315063645, :tw => 0.000,         :captured_response_cookie => nil,
+            :frontend_name => 'as-proxy',   :tc => 0.000,         :clientside_persistence_cookie => 'N',
+            :server_name => 'mc-search-2',  :tr => 0.730,         :serverside_persistence_cookie => 'N',
+            :status_code => 200,            :tt => 0.731,         :termination_event_code => nil,
+            :bytes_read => 29404,           :listener_conn => 54, :terminated_session_state => nil,
+            :backend_queue => 0,            :process_conn => 54,  :captured_request_headers => '{66.249.68.216}',
+            :srv_queue => 0,                :srv_conn => 2,       :captured_response_headers => nil,
             :http_request => 'GET /neighbor/26014153 HTTP/1.0')
     }
 
     it { should parse_line(sample_haproxy11, 'an haproxy 1.1 access line').and_capture(
             :client_ip => '127.0.0.1',      :tq => 0.009,       :captured_request_cookie => nil,
-            :timestamp => 20031015083217,   :tc => 0.007,       :captured_response_cookie => nil,
+            :accept_date => 20031015083217, :tc => 0.007,       :captured_response_cookie => nil,
             :frontend_name => 'relais-http',:tr => 0.014,       :clientside_persistence_cookie => nil,
             :server_name => 'Srv1',         :tt => 0.030,       :serverside_persistence_cookie => nil,
             :status_code => 502,            :listener_conn => 2,:termination_event_code => 'P',
@@ -56,14 +56,14 @@ describe RequestLogAnalyzer::FileFormat::Haproxy do
     }
     
     it { should parse_line(sample_errors, 'a failed access line').and_capture(
-            :timestamp => 20031015151906, :tq => nil,    :captured_request_cookie => nil,
-            :server_name => '<NOSRV>',    :tw => nil,    :captured_response_cookie => nil,
-            :bytes_read => 2750,          :tc => nil,    :clientside_persistence_cookie => nil,
-            :retries => 2,                :tr => nil,    :serverside_persistence_cookie => nil,
-            :http_request => nil,         :tt => 50.001, :termination_event_code => 'c',
-                                                         :terminated_session_state => 'R',
-                                                         :captured_request_headers => nil,
-                                                         :captured_response_headers => nil)
+            :accept_date => 20031015151906, :tq => nil,    :captured_request_cookie => nil,
+            :server_name => '<NOSRV>',      :tw => nil,    :captured_response_cookie => nil,
+            :bytes_read => 2750,            :tc => nil,    :clientside_persistence_cookie => nil,
+            :retries => 2,                  :tr => nil,    :serverside_persistence_cookie => nil,
+            :http_request => nil,           :tt => 50.001, :termination_event_code => 'c',
+                                                           :terminated_session_state => 'R',
+                                                           :captured_request_headers => nil,
+                                                           :captured_response_headers => nil)
     }
     
     it { should_not parse_line('nonsense') }

--- a/spec/unit/file_format/haproxy_format_spec.rb
+++ b/spec/unit/file_format/haproxy_format_spec.rb
@@ -3,18 +3,23 @@ require 'spec_helper'
 describe RequestLogAnalyzer::FileFormat::Haproxy do
 
   subject { RequestLogAnalyzer::FileFormat.load(:haproxy) }
+  let(:log_parser) { RequestLogAnalyzer::Source::LogParser.new(subject) }
 
   it { should be_well_formed }
-  it { should have_line_definition(:access).capturing(:client_ip, :timestamp, :frontend_name, :backend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :actconn, :feconn, :beconn, :srv_conn, :retries, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request) }
+
+  it { should have_line_definition(:haproxy13).capturing(:client_ip, :timestamp, :frontend_name, :backend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :actconn, :feconn, :beconn, :srv_conn, :retries, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request) }
+  it { should have_line_definition(:haproxy12).capturing(:client_ip, :timestamp, :frontend_name, :server_name, :tq, :tw, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :srv_conn, :listener_conn, :process_conn, :srv_queue, :backend_queue, :captured_request_headers, :captured_response_headers, :http_request) }
+  it { should have_line_definition(:haproxy11).capturing(:client_ip, :timestamp, :frontend_name, :server_name, :tq, :tc, :tr, :tt, :status_code, :bytes_read, :captured_request_cookie, :captured_response_cookie, :termination_event_code, :terminated_session_state, :clientside_persistence_cookie, :serverside_persistence_cookie, :listener_conn, :process_conn, :captured_request_headers, :captured_response_headers, :http_request) }
+
   it { should have(14).report_trackers }
 
-  let(:sample1) { 'Feb  6 12:14:14 localhost haproxy[14389]: 10.0.1.2:33317 [06/Feb/2009:12:14:14.655] http-in static/srv1 10/0/30/69/109 200 2750 - - ---- 1/1/1/1/0 0/0 {1wt.eu} {} "GET /index.html HTTP/1.1"' }
-  let(:sample2) { 'haproxy[18113]: 127.0.0.1:34549 [15/Oct/2003:15:19:06.103] px-http px-http/<NOSRV> -1/-1/-1/-1/+50001 408 +2750 - - cR-- 2/2/2/0/+2 0/0 ""' }
-  
-  # let(:sample3) { 'Mar 15 06:36:49 localhost haproxy[9367]: 127.0.0.1:38990 [15/Mar/2011:06:36:45.103] as-proxy mc-search-2 0/0/0/730/731 200 29404 - - --NN 2/54/54 0/0 {66.249.68.216} {} "GET /neighbor/26014153 HTTP/1.0" ' }
+  let(:sample_haproxy13) { 'Feb  6 12:14:14 localhost haproxy[14389]: 10.0.1.2:33317 [06/Feb/2009:12:14:14.655] http-in static/srv1 10/0/30/69/109 200 2750 - - ---- 1/1/1/1/0 0/0 {1wt.eu} {} "GET /index.html HTTP/1.1"' }
+  let(:sample_haproxy12) { 'Mar 15 06:36:49 localhost haproxy[9367]: 127.0.0.1:38990 [15/Mar/2011:06:36:45.103] as-proxy mc-search-2 0/0/0/730/731 200 29404 - - --NN 2/54/54 0/0 {66.249.68.216} {} "GET /neighbor/26014153 HTTP/1.0" ' }
+  let(:sample_haproxy11) { 'haproxy[674]: 127.0.0.1:33320 [15/Oct/2003:08:32:17] relais-http Srv1 9/7/14/30 502 243 - - PH-- 2/3 "GET /cgi-bin/bug.cgi? HTTP/1.0"' }
+  let(:sample_errors)    { 'haproxy[18113]: 127.0.0.1:34549 [15/Oct/2003:15:19:06.103] px-http px-http/<NOSRV> -1/-1/-1/-1/+50001 408 +2750 - - cR-- 2/2/2/0/+2 0/0 ""' }
 
   describe '#parse_line' do
-    it { should parse_line(sample1, 'an acess line').and_capture(
+    it { should parse_line(sample_haproxy13, 'an haproxy 1.3 access line').and_capture(
             :client_ip => '10.0.1.2',     :tq => 0.010,   :captured_request_cookie => nil,
             :timestamp => 20090206121414, :tw => 0.000,   :captured_response_cookie => nil,
             :frontend_name => 'http-in',  :tc => 0.030,   :clientside_persistence_cookie => nil,
@@ -26,8 +31,31 @@ describe RequestLogAnalyzer::FileFormat::Haproxy do
             :retries => 0,                :srv_conn => 1, :srv_queue => 0,
             :http_request => 'GET /index.html HTTP/1.1')
     }
+
+    it { should parse_line(sample_haproxy12, 'an haproxy 1.2 access line').and_capture(
+            :client_ip => '127.0.0.1',    :tq => 0.000,         :captured_request_cookie => nil,
+            :timestamp => 20110315063645, :tw => 0.000,         :captured_response_cookie => nil,
+            :frontend_name => 'as-proxy', :tc => 0.000,         :clientside_persistence_cookie => 'N',
+            :server_name => 'mc-search-2',:tr => 0.730,         :serverside_persistence_cookie => 'N',
+            :status_code => 200,          :tt => 0.731,         :termination_event_code => nil,
+            :bytes_read => 29404,         :listener_conn => 54, :terminated_session_state => nil,
+            :backend_queue => 0,          :process_conn => 54,  :captured_request_headers => '{66.249.68.216}',
+            :srv_queue => 0,              :srv_conn => 2,       :captured_response_headers => nil,
+            :http_request => 'GET /neighbor/26014153 HTTP/1.0')
+    }
+
+    it { should parse_line(sample_haproxy11, 'an haproxy 1.1 access line').and_capture(
+            :client_ip => '127.0.0.1',      :tq => 0.009,       :captured_request_cookie => nil,
+            :timestamp => 20031015083217,   :tc => 0.007,       :captured_response_cookie => nil,
+            :frontend_name => 'relais-http',:tr => 0.014,       :clientside_persistence_cookie => nil,
+            :server_name => 'Srv1',         :tt => 0.030,       :serverside_persistence_cookie => nil,
+            :status_code => 502,            :listener_conn => 2,:termination_event_code => 'P',
+            :bytes_read => 243,             :process_conn => 3, :terminated_session_state => 'H',
+            :captured_request_headers => nil,                   :captured_response_headers => nil,
+            :http_request => nil)
+    }
     
-    it { should parse_line(sample2, 'a failed access line').and_capture(
+    it { should parse_line(sample_errors, 'a failed access line').and_capture(
             :timestamp => 20031015151906, :tq => nil,    :captured_request_cookie => nil,
             :server_name => '<NOSRV>',    :tw => nil,    :captured_response_cookie => nil,
             :bytes_read => 2750,          :tc => nil,    :clientside_persistence_cookie => nil,
@@ -38,17 +66,15 @@ describe RequestLogAnalyzer::FileFormat::Haproxy do
                                                          :captured_response_headers => nil)
     }
     
-    # it { should parse_line(sample3, 'a third access line') }
-    
     it { should_not parse_line('nonsense') }
   end
   
   describe '#parse_io' do
     let(:log_parser) { RequestLogAnalyzer::Source::LogParser.new(subject) }
-    let(:snippet)    { log_snippet(sample1, sample2, 'nonsense') }
+    let(:snippet)    { log_snippet(sample_haproxy13, sample_haproxy12, sample_haproxy11, sample_errors, 'nonsense') }
     
     it "should parse a log snippet without warnings" do
-      log_parser.should_receive(:handle_request).exactly(2).times
+      log_parser.should_receive(:handle_request).exactly(4).times
       log_parser.should_not_receive(:warn)
       log_parser.parse_io(snippet)
     end


### PR DESCRIPTION
Hi,

At last I added the code required to parse older versions of haproxy's logs. Apart from not breaking the specs despite slight refactoring, the additional code doesn't cause any slowdown parsing my 400k-lines test logfile :-)

A note about the 2nd patch (ff6e1cfd), as it reverts the renaming you made in 3c57be43: my idea was to consistently match the symbol names with the names used in HAProxy's documentation[1]. I split this change in a seperate patch, this way you can easily drop it if you disagree.

Cheers,
Marc

[1] http://code.google.com/p/haproxy-docs/wiki/HTTPLogFormat
