### PR TITLE
Fixed DB Console not opening in Rails 3.0.x and other bugs

### DIFF
--- a/bin/request-log-analyzer
+++ b/bin/request-log-analyzer
@@ -17,6 +17,8 @@ begin
 
     command_line.command(:console) do |cons|
       cons.option(:database, :alias => :d, :required => true)
+      cons.option(:format, :alias => :f)
+      cons.option(:apache_format)
     end
 
     command_line.command(:strip) do |strip|

--- a/bin/request-log-analyzer
+++ b/bin/request-log-analyzer
@@ -37,6 +37,8 @@ begin
     command_line.option(:mail, :alias => :m)
     command_line.option(:mailhost, :default => 'localhost')
     command_line.option(:mailsubject)
+    command_line.option(:mailfrom)
+    command_line.option(:mailfromalias)
     command_line.option(:parse_strategy, :default => 'assume-correct')
     command_line.option(:yaml)
     command_line.option(:dump) # To be deprecated

--- a/lib/cli/database_console.rb
+++ b/lib/cli/database_console.rb
@@ -8,7 +8,7 @@ class DatabaseConsole
   end
 
   def run!
-    libraries = ['irb/completion', 'rubygems', './lib/request_log_analyzer', './lib/cli/database_console_init']
+    libraries = ['irb/completion', 'rubygems','./lib/cli/database_console_init']
     libaries_string = libraries.map { |l| "-r #{l}" }.join(' ')
 
     ENV['RLA_DBCONSOLE_DATABASE'] = @arguments[:database]

--- a/lib/cli/database_console_init.rb
+++ b/lib/cli/database_console_init.rb
@@ -1,5 +1,7 @@
 # Setup the include path
-$:.unshift(File.expand_path('..', File.dirname(__FILE__))
+$:.unshift(File.expand_path('..', File.dirname(__FILE__)))
+require 'request_log_analyzer'
+require 'request_log_analyzer/database'
 
 $database = RequestLogAnalyzer::Database.new(ENV['RLA_DBCONSOLE_DATABASE'])
 $database.load_database_schema!

--- a/lib/request_log_analyzer/controller.rb
+++ b/lib/request_log_analyzer/controller.rb
@@ -44,6 +44,8 @@ module RequestLogAnalyzer
       options[:report_amount]  = arguments[:report_amount]
       options[:mailhost]       = arguments[:mailhost]
       options[:mailsubject]    = arguments[:mailsubject]
+      options[:mailfrom]       = arguments[:mailfrom]
+      options[:mailfromalias]  = arguments[:mailfromalias]
       options[:silent]         = arguments[:silent]
       options[:parse_strategy] = arguments[:parse_strategy]
 
@@ -163,7 +165,8 @@ module RequestLogAnalyzer
         output_object = %w[File StringIO].include?(options[:file].class.name) ? options[:file] : File.new(options[:file], "w+")
         output_args   = {:width => 80, :color => false, :characters => :ascii, :sort => output_sort, :amount => output_amount }
       elsif options[:mail]
-        output_object = RequestLogAnalyzer::Mailer.new(options[:mail], options[:mailhost], :subject => options[:mailsubject])
+        output_object = RequestLogAnalyzer::Mailer.new(options[:mail], options[:mailhost], :subject => options[:mailsubject],
+                                                      :from =>options[:mailfrom], :from_alias => options[:mailfromalias])
         output_args   = {:width => 80, :color => false, :characters => :ascii, :sort => output_sort, :amount => output_amount  }
       else
         output_object = STDOUT

--- a/lib/request_log_analyzer/database/base.rb
+++ b/lib/request_log_analyzer/database/base.rb
@@ -24,8 +24,8 @@ class RequestLogAnalyzer::Database::Base < ActiveRecord::Base
     klass.line_definition = definition
 
     # Set relations with requests and sources table
-    klass.belongs_to :request
-    klass.belongs_to :source
+    klass.belongs_to :request, :class_name => RequestLogAnalyzer::Database::Request.name
+    klass.belongs_to :source, :class_name => RequestLogAnalyzer::Database::Source.name
 
     # Serialize complex fields into the database
     definition.captures.select { |c| c.has_key?(:provides) }.each do |capture|
@@ -45,12 +45,12 @@ class RequestLogAnalyzer::Database::Base < ActiveRecord::Base
     klass.set_table_name(table)
 
     if klass.column_names.include?('request_id')
-      klass.belongs_to :request
+      klass.belongs_to :request, :class_name => RequestLogAnalyzer::Database::Request.name
       RequestLogAnalyzer::Database::Request.has_many table.to_sym
     end
 
     if klass.column_names.include?('source_id')
-      klass.belongs_to :source
+      klass.belongs_to :source, :class_name => RequestLogAnalyzer::Database::Source.name
       RequestLogAnalyzer::Database::Source.has_many table.to_sym
     end
 

--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -43,8 +43,7 @@ module RequestLogAnalyzer::FileFormat
     line_definition :completed do |line|
       line.footer = true
       line.teaser = /Completed /
-      line.regexp = /Completed (\d+)? .*in (\d+(?:\.\d+)?)ms(?:[^\(]*\(Views: (\d+(?:\.\d+)?)ms .* ActiveRecord: (\d+(?:\.\d+)?)ms(?: .* Solr: (\d+(?:\.\d+)?)ms)?(?: .* Redis: (\d+(?:\.\d+)?)ms)?.*\))?/
-      
+      line.regexp = /Completed (\d+)? .*in (\d+(?:\.\d+)?)ms[^\(]*\(Views: (\d+(?:\.\d+)?)ms .* ActiveRecord: (\d+(?:\.\d+)?)ms(?: .* Solr: (\d+(?:\.\d+)?)ms)?(?: .* Redis: (\d+(?:\.\d+)?)ms)?.*\)/
       line.capture(:status).as(:integer)
       line.capture(:duration).as(:duration, :unit => :msec)
       line.capture(:view).as(:duration, :unit => :msec)
@@ -55,15 +54,19 @@ module RequestLogAnalyzer::FileFormat
     
     # ActionView::Template::Error (undefined local variable or method `field' for #<Class>) on line #3 of /Users/willem/Code/warehouse/app/views/queries/execute.csv.erb:
     line_definition :failure do |line|
-      line.footer = true
       line.regexp = /((?:[A-Z]\w*[a-z]\w+\:\:)*[A-Z]\w*[a-z]\w+) \((.*)\)(?: on line #(\d+) of (.+))?\:\s*$/
-
       line.capture(:error)
       line.capture(:message)
       line.capture(:line).as(:integer)
       line.capture(:file)
     end
-    
+
+    line_definition :trace do |line|
+      line.regexp = /(.+):(\d+):.+\`(.+)\'/
+      line.capture(:file)
+      line.capture(:line_number).as(:integer)
+      line.capture(:function)
+    end
     # # Not parsed at the moment:
     #  SQL (0.2ms)  SET SQL_AUTO_IS_NULL=0
     #  Query Load (0.4ms)  SELECT `queries`.* FROM `queries`

--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -43,12 +43,14 @@ module RequestLogAnalyzer::FileFormat
     line_definition :completed do |line|
       line.footer = true
       line.teaser = /Completed /
-      line.regexp = /Completed (\d+)? .*in (\d+(?:\.\d+)?)ms(?:[^\(]*\(Views: (\d+(?:\.\d+)?)ms .* ActiveRecord: (\d+(?:\.\d+)?)ms.*\))?/
+      line.regexp = /Completed (\d+)? .*in (\d+(?:\.\d+)?)ms(?:[^\(]*\(Views: (\d+(?:\.\d+)?)ms .* ActiveRecord: (\d+(?:\.\d+)?)ms(?: .* Solr: (\d+(?:\.\d+)?)ms)?(?: .* Redis: (\d+(?:\.\d+)?)ms)?.*\))?/
       
       line.capture(:status).as(:integer)
       line.capture(:duration).as(:duration, :unit => :msec)
       line.capture(:view).as(:duration, :unit => :msec)
       line.capture(:db).as(:duration, :unit => :msec)
+      line.capture(:solr).as(:duration, :unit => :msec)
+      line.capture(:redis).as(:duration, :unit => :msec)
     end
     
     # ActionView::Template::Error (undefined local variable or method `field' for #<Class>) on line #3 of /Users/willem/Code/warehouse/app/views/queries/execute.csv.erb:
@@ -82,6 +84,8 @@ module RequestLogAnalyzer::FileFormat
       analyze.duration :duration, :category => REQUEST_CATEGORIZER, :title => "Request duration",    :line_type => :completed
       analyze.duration :view,     :category => REQUEST_CATEGORIZER, :title => "View rendering time", :line_type => :completed
       analyze.duration :db,       :category => REQUEST_CATEGORIZER, :title => "Database time",       :line_type => :completed
+      analyze.duration :solr,     :category => REQUEST_CATEGORIZER, :title => "Solr time",           :line_type => :completed
+      analyze.duration :redis,    :category => REQUEST_CATEGORIZER, :title => "Redis time",          :line_type => :completed
       
       analyze.frequency :category => REQUEST_CATEGORIZER, :title => 'Process blockers (> 1 sec duration)',
         :if => lambda { |request| request[:duration] && request[:duration] > 1.0 }

--- a/lib/request_log_analyzer/mailer.rb
+++ b/lib/request_log_analyzer/mailer.rb
@@ -29,7 +29,7 @@ module RequestLogAnalyzer
     # Send all data in @data to the email address used during initialization.
     # Returns array containg [message_data, from_email_address, to_email_address] of sent email.
     def mail
-      from          = @options[:from]        || 'contact@railsdoctors.com'
+      from          = @options[:from]        || 'noreplay@z33k.com'
       from_alias    = @options[:from_alias]  || 'Request-log-analyzer reporter'
       to_alias      = @options[:to_alias]    || to
       subject       = @options[:subject]     || "Request log analyzer report - generated on #{Time.now.to_s}"

--- a/spec/unit/database/base_class_spec.rb
+++ b/spec/unit/database/base_class_spec.rb
@@ -106,7 +106,7 @@ describe RequestLogAnalyzer::Database::Base do
     end
 
     it "should create the :belongs_to relation to the source class" do
-      @klass.should_receive(:belongs_to).with(:source, {:class_name=>"RequestLogAnalyzer::Database::Request"})
+      @klass.should_receive(:belongs_to).with(:source, {:class_name=>"RequestLogAnalyzer::Database::Source"})
       RequestLogAnalyzer::Database::Base.subclass_from_table('completed_lines')
     end
 

--- a/spec/unit/database/base_class_spec.rb
+++ b/spec/unit/database/base_class_spec.rb
@@ -42,7 +42,7 @@ describe RequestLogAnalyzer::Database::Base do
     end
 
     it "should set the :belongs_to relationship with the Request class" do
-      @orm_class.should_receive(:belongs_to).with(:request)
+      @orm_class.should_receive(:belongs_to).with(:request, {:class_name=>"RequestLogAnalyzer::Database::Request"})
       RequestLogAnalyzer::Database::Base.subclass_from_line_definition(@line_definition)
     end
 
@@ -57,7 +57,7 @@ describe RequestLogAnalyzer::Database::Base do
     end
 
     it "should set the :belongs_to relationship with the Source class" do
-      @orm_class.should_receive(:belongs_to).with(:source)
+      @orm_class.should_receive(:belongs_to).with(:source, {:class_name=>"RequestLogAnalyzer::Database::Source"})
       RequestLogAnalyzer::Database::Base.subclass_from_line_definition(@line_definition)
     end
 
@@ -96,7 +96,7 @@ describe RequestLogAnalyzer::Database::Base do
     end
 
     it "should create the :belongs_to relation to the request class" do
-      @klass.should_receive(:belongs_to).with(:request)
+      @klass.should_receive(:belongs_to).with(:request, {:class_name=>"RequestLogAnalyzer::Database::Request"})
       RequestLogAnalyzer::Database::Base.subclass_from_table('completed_lines')
     end
 
@@ -106,7 +106,7 @@ describe RequestLogAnalyzer::Database::Base do
     end
 
     it "should create the :belongs_to relation to the source class" do
-      @klass.should_receive(:belongs_to).with(:source)
+      @klass.should_receive(:belongs_to).with(:source, {:class_name=>"RequestLogAnalyzer::Database::Request"})
       RequestLogAnalyzer::Database::Base.subclass_from_table('completed_lines')
     end
 


### PR DESCRIPTION
Hello,

I was trying to use the RLA to dump into the DB which was fine, but opening it up in the provided console failed. There was issues in the command line arguments, a missing bracket in a library setting, and also files were not loading once they were in the IRB commandline. Moved around and fixed the issues and no longer get warnings.

Once in the console, all calls to an association to Source or Request would fail. This was because it was trying to find the class. XXX::Source or XXX::Request. Fixed this by adding in explicit class names to the associations. This required specs to be altered as well.

All specs passing.
- Cameron
