### PR TITLE
Fix for issue #113 require:LoadError

### DIFF
--- a/lib/cli/database_console.rb
+++ b/lib/cli/database_console.rb
@@ -1,4 +1,3 @@
-
 class DatabaseConsole
 
   IRB = RUBY_PLATFORM =~ /(:?mswin|mingw)/ ? 'irb.bat' : 'irb'
@@ -8,7 +7,7 @@ class DatabaseConsole
   end
 
   def run!
-    libraries = ['irb/completion', 'rubygems','./lib/cli/database_console_init']
+    libraries = ['irb/completion', 'rubygems','cli/database_console_init']
     libaries_string = libraries.map { |l| "-r #{l}" }.join(' ')
 
     ENV['RLA_DBCONSOLE_DATABASE'] = @arguments[:database]


### PR DESCRIPTION
Minor adjustment to libraries array. Original used relative path reference, which breaks because IRB current working directory is not same as the gem dir. Console still appears to work otherwise!
