### PR TITLE
Group Rails3 RoutingErrors with HTTP method

### DIFF
--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -103,7 +103,8 @@ module RequestLogAnalyzer::FileFormat
       analyze.frequency :category => REQUEST_CATEGORIZER, :title => 'Process blockers (> 1 sec duration)',
         :if => lambda { |request| request[:duration] && request[:duration] > 1.0 }
 
-      analyze.frequency :missing_resource, :title => "Routing Errors"
+      analyze.frequency :category => lambda{|x| "[#{x[:missing_resource_method]}] #{x[:missing_resource]}"},
+        :title => "Routing Errors", :if => lambda{ |request| !request[:missing_resource].nil? }
     end
 
     class Request < RequestLogAnalyzer::Request


### PR DESCRIPTION
I realized that it would be better to group the 404 with the method type too. So a GET /missing and a POST /missing are reported separately.

Shouldve sent this with the earlier post but didnt understand the usage unti now.
