### PR TITLE
Modified rails3 patterns to tolerate no indentation

### DIFF
--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -32,8 +32,8 @@ module RequestLogAnalyzer::FileFormat
 
     # Parameters: {"action"=>"cached", "controller"=>"cached"}
     line_definition :parameters do |line|
-      line.teaser = / Parameters:/
-      line.regexp = / Parameters:\s+(\{.*\})/
+      line.teaser = /(?:^| )Parameters:/
+      line.regexp = /(?:^| )Parameters:\s+(\{.*\})/
       line.capture(:params).as(:eval)
     end
 
@@ -73,8 +73,8 @@ module RequestLogAnalyzer::FileFormat
     # Rendered queries/index.html.erb (0.6ms)
     line_definition :rendered do |line|
       line.compound = [:partial_duration]
-      line.teaser = / Rendered /
-      line.regexp = / Rendered ([a-zA-Z0-9_\-\/.]+(?:\/[a-zA-Z0-9_\-.]+)+)(?:\ within\ .*?)? \((\d+(?:\.\d+)?)ms\)/
+      line.teaser = /(?:^| )Rendered /
+      line.regexp = /(?:^| )Rendered ([a-zA-Z0-9_\-\/.]+(?:\/[a-zA-Z0-9_\-.]+)+)(?:\ within\ .*?)? \((\d+(?:\.\d+)?)ms\)/
       line.capture(:rendered_file)
       line.capture(:partial_duration).as(:duration, :unit => :msec)
     end

--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -32,8 +32,8 @@ module RequestLogAnalyzer::FileFormat
 
     # Parameters: {"action"=>"cached", "controller"=>"cached"}
     line_definition :parameters do |line|
-      line.teaser = /(?:^| )Parameters:/
-      line.regexp = /(?:^| )Parameters:\s+(\{.*\})/
+      line.teaser = /\bParameters:/
+      line.regexp = /\bParameters:\s+(\{.*\})/
       line.capture(:params).as(:eval)
     end
 
@@ -73,8 +73,8 @@ module RequestLogAnalyzer::FileFormat
     # Rendered queries/index.html.erb (0.6ms)
     line_definition :rendered do |line|
       line.compound = [:partial_duration]
-      line.teaser = /(?:^| )Rendered /
-      line.regexp = /(?:^| )Rendered ([a-zA-Z0-9_\-\/.]+(?:\/[a-zA-Z0-9_\-.]+)+)(?:\ within\ .*?)? \((\d+(?:\.\d+)?)ms\)/
+      line.teaser = /\bRendered /
+      line.regexp = /\bRendered ([a-zA-Z0-9_\-\/.]+(?:\/[a-zA-Z0-9_\-.]+)+)(?:\ within\ .*?)? \((\d+(?:\.\d+)?)ms\)/
       line.capture(:rendered_file)
       line.capture(:partial_duration).as(:duration, :unit => :msec)
     end

--- a/spec/unit/file_format/rails3_format_spec.rb
+++ b/spec/unit/file_format/rails3_format_spec.rb
@@ -56,6 +56,11 @@ describe RequestLogAnalyzer::FileFormat::Rails3 do
       subject.should parse_line(line).as(:parameters).and_capture(:params => {:action => 'cached', :controller => 'cached'})
     end
 
+    it "should parse a :parameters line with no indentation correctly" do
+      line = 'Parameters: {"action"=>"cached", "controller"=>"cached"}'
+      subject.should parse_line(line).as(:parameters).and_capture(:params => {:action => 'cached', :controller => 'cached'})
+    end
+
     it "should parse :completed lines correctly" do
       line = 'Completed 200 OK in 170ms (Views: 78.0ms | ActiveRecord: 48.2ms)'
       subject.should parse_line(line).as(:completed).and_capture(
@@ -89,6 +94,11 @@ describe RequestLogAnalyzer::FileFormat::Rails3 do
 
     it "should parse :rendered lines as an array" do
       line = " Rendered queries/index.html.erb (0.6ms)"
+      subject.should parse_line(line).as(:rendered).and_capture(:partial_duration => [0.0006])
+    end
+
+    it "should parse :rendered lines with no identation as an array" do
+      line = "Rendered queries/index.html.erb (0.6ms)"
       subject.should parse_line(line).as(:rendered).and_capture(:partial_duration => [0.0006])
     end
   end


### PR DESCRIPTION
Some logging mechanisms (e.g. syslog) tend to remove indentation from
parsed log lines. The new regex patterns will cover these cases.
