### PR TITLE
Code cosmetics and allow classical inheritance to Just Work.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec

--- a/lib/request_log_analyzer/file_format.rb
+++ b/lib/request_log_analyzer/file_format.rb
@@ -206,27 +206,9 @@ module RequestLogAnalyzer::FileFormat
     # CLASS METHODS for format definition
     ####################################################################################
 
-    # Registers the line and report definers and the request class for a subclass.
-    def self.inherited(subclass)
-
-      line_definer   = subclass.superclass.line_definer.clone
-      report_definer = subclass.superclass.report_definer.clone
-      request_class  = Class.new(subclass.superclass::Request)
-
-      # Line and report definers in the subclass are clones of those in the superclass.
-      subclass.class_eval do
-        instance_variable_set(:@line_definer, line_definer)
-        instance_variable_set(:@report_definer, report_definer)
-        class << self; attr_accessor :line_definer, :report_definer; end
-      end
-
-      # Request class in the subclass is that of the superclass, unless the subclass defines it's own.
-      subclass.const_set('Request', request_class) unless subclass.const_defined?('Request')
-    end
-
     # Specifies a single line defintions.
     def self.line_definition(name, &block)
-      @line_definer.define_line(name, &block)
+      line_definer.define_line(name, &block)
     end
 
     # Specifies multiple line definitions at once using a block
@@ -244,10 +226,18 @@ module RequestLogAnalyzer::FileFormat
       yield(self.report_definer)
     end
 
-    # Helpers used by RequestLogAnalyzer::FileFormat::Base.
+    # Setup the default line definer.
+    def self.line_definer
+      @line_definer ||= ::RequestLogAnalyzer::LineDefinition::Definer.new
+    end
+
+    # Setup the default report definer.
+    def self.report_definer
+      @report_definer ||= ::RequestLogAnalyzer::Aggregator::Summarizer::Definer.new
+    end
+
+    # Setup the default Request class.
     Request = ::RequestLogAnalyzer::Request
-    def self.line_definer   ; ::RequestLogAnalyzer::LineDefinition::Definer.new         ; end
-    def self.report_definer ; ::RequestLogAnalyzer::Aggregator::Summarizer::Definer.new ; end
 
     ####################################################################################
     # Instantiation

--- a/tasks/github-gem.rake
+++ b/tasks/github-gem.rake
@@ -6,15 +6,20 @@ require 'set'
 
 module GithubGem
 
-  # Detects the gemspc file of this project using heuristics.
+  # Detects the gemspec file of this project using heuristics.
   def self.detect_gemspec_file
     FileList['*.gemspec'].first
   end
 
-  # Detects the main include file of this project using heuristics
+  # Detects the main include file of this project using heuristics.
   def self.detect_main_include
-    if File.exist?(File.expand_path("../lib/#{File.basename(detect_gemspec_file, '.gemspec').gsub(/-/, '/')}.rb", detect_gemspec_file))
-      "lib/#{File.basename(detect_gemspec_file, '.gemspec').gsub(/-/, '/')}.rb"
+    gemspec_file          = detect_gemspec_file
+    gemspec_file_basename = File.basename(gemspec_file, '.gemspec')
+    main_include_file     = gemspec_file_basename.gsub(/-/, '/') + '.rb'
+
+    # Prefer a file named like the gemspec file; else, load the first Ruby file.
+    if File.exist? File.expand_path("../lib/#{main_include_file}", gemspec_file)
+      "lib/#{main_include_file}"
     elsif FileList['lib/*.rb'].length == 1
       FileList['lib/*.rb'].first
     else
@@ -27,7 +32,9 @@ module GithubGem
     include Rake::DSL if Rake.const_defined?('DSL')
 
     attr_reader   :gemspec, :modified_files
-    attr_accessor :gemspec_file, :task_namespace, :main_include, :root_dir, :spec_pattern, :test_pattern, :remote, :remote_branch, :local_branch
+
+    attr_accessor :gemspec_file, :local_branch, :main_include, :remote, :remote_branch,
+                  :root_dir, :spec_pattern,:task_namespace, :test_pattern
 
     # Initializes the settings, yields itself for configuration
     # and defines the rake tasks based on the gemspec file.


### PR DESCRIPTION
I wanted to use RLA on a custom log today, so I was code reading and tried for a bit of gardening.  Unsure if you want this PR, it:
- trivially fixes the Bundler warning re: `:rubygems`
- makes the `github_gem.rake` task a bit easier to grok
- removes the inherited hook by defining methods on `RLA::FF::Base`

On this last bit, I thought the special-case of `subclass.superclass` revealed a duck-type, and the implementation was just doing classical OO-inheritance, e.g. if subclass.superclass.methodX, then make subclass.methodX call it.  (Although the code was a bit tricky to unwind.)

I re-factored by adding `*_definers` and a `Request` class to `RLA::FF::Base` itself. No code used the setter (the original `attr_accessor` could have been `attr_reader`).  So, no `attr_*` helpers are needed, just store the definers in ivars when getting them.  With that done, the inherited hook can go.

Tests all pass. Hopefully I haven't broken anything for which there are no tests, or substantially wasted your time. ;-)
