### PR TITLE
Enable the sender name and email address to be specified on the command line

### DIFF
--- a/bin/request-log-analyzer
+++ b/bin/request-log-analyzer
@@ -91,7 +91,7 @@ rescue CommandLine::Error => e
   puts "  --mail <emailaddress>      Send report to an email address."
   puts "  --mailhost <server>        Use the given server as the SMTP server for sending email."
   puts "  --mailfrom <address>       Overwrite default email sender address."
-  puts "  --mailfrom-name <name>     Overwrite default email serder name."
+  puts "  --mailfrom-name <name>     Overwrite default email sender name."
   puts "  --mailsubject <text>       Overwrite default mailsubject."
   puts "  --no-progress              Hide the progress bar."
   puts "  --output <format>          Output format. Supports 'html' and 'fixed_width'."

--- a/bin/request-log-analyzer
+++ b/bin/request-log-analyzer
@@ -36,6 +36,8 @@ begin
     command_line.option(:file, :alias => :e)
     command_line.option(:mail, :alias => :m)
     command_line.option(:mailhost, :default => 'localhost')
+    command_line.option(:mailfrom)
+    command_line.option(:mailfrom_name)
     command_line.option(:mailsubject)
     command_line.option(:parse_strategy, :default => 'assume-correct')
     command_line.option(:yaml)
@@ -88,6 +90,8 @@ rescue CommandLine::Error => e
   puts "  --file <filename>          Redirect output to file."
   puts "  --mail <emailaddress>      Send report to an email address."
   puts "  --mailhost <server>        Use the given server as the SMTP server for sending email."
+  puts "  --mailfrom <address>       Overwrite default email sender address."
+  puts "  --mailfrom-name <name>     Overwrite default email serder name."
   puts "  --mailsubject <text>       Overwrite default mailsubject."
   puts "  --no-progress              Hide the progress bar."
   puts "  --output <format>          Output format. Supports 'html' and 'fixed_width'."

--- a/lib/request_log_analyzer/controller.rb
+++ b/lib/request_log_analyzer/controller.rb
@@ -43,6 +43,8 @@ module RequestLogAnalyzer
       options[:report_sort]    = arguments[:report_sort]
       options[:report_amount]  = arguments[:report_amount]
       options[:mailhost]       = arguments[:mailhost]
+      options[:mailfrom]       = arguments[:mailfrom]
+      options[:mailfrom_name]  = arguments[:mailfrom_name]
       options[:mailsubject]    = arguments[:mailsubject]
       options[:silent]         = arguments[:silent]
       options[:parse_strategy] = arguments[:parse_strategy]
@@ -106,6 +108,8 @@ module RequestLogAnalyzer
     # * <tt>:format</tt> :rails, {:apache => 'FORMATSTRING'}, :merb, :amazon_s3, :mysql or RequestLogAnalyzer::FileFormat class. (Defaults to :rails).
     # * <tt>:mail</tt> Email the results to this email address.
     # * <tt>:mailhost</tt> Email the results to this mail server.
+    # * <tt>:mailfrom</tt> Set the Email sender address.
+    # * <tt>:mailfrom_alias</tt> Set the Email sender name.
     # * <tt>:mailsubject</tt> Email subject.
     # * <tt>:no_progress</tt> Do not display the progress bar (increases parsing speed).
     # * <tt>:output</tt> 'FixedWidth', 'HTML' or RequestLogAnalyzer::Output class. Defaults to 'FixedWidth'.
@@ -165,7 +169,7 @@ module RequestLogAnalyzer
         output_object = %w[File StringIO].include?(options[:file].class.name) ? options[:file] : File.new(options[:file], "w+")
         output_args   = {:width => 80, :color => false, :characters => :ascii, :sort => output_sort, :amount => output_amount }
       elsif options[:mail]
-        output_object = RequestLogAnalyzer::Mailer.new(options[:mail], options[:mailhost], :subject => options[:mailsubject])
+        output_object = RequestLogAnalyzer::Mailer.new(options[:mail], options[:mailhost], :subject => options[:mailsubject], :from => options[:mailfrom], :from_alias => options[:mailfrom_name])
         output_args   = {:width => 80, :color => false, :characters => :ascii, :sort => output_sort, :amount => output_amount  }
       else
         output_object = STDOUT

--- a/spec/integration/mailer_spec.rb
+++ b/spec/integration/mailer_spec.rb
@@ -52,6 +52,36 @@ describe RequestLogAnalyzer, 'running mailer integration' do
     find_string_in_file("Subject: TESTSUBJECT", @log_file).should_not be_nil
   end
 
+  it "should allow a custom mail sender address" do
+    RequestLogAnalyzer::Controller.build(
+      :mail         => 'root@localhost',
+      :mailhost     => 'localhost:2525',
+      :mailfrom     => 'customaddr@example.com',
+      :source_files => log_fixture(:rails_1x),
+      :format       => RequestLogAnalyzer::FileFormat::Rails,
+      :no_progress  => true
+    ).run!
+
+    Process.wait # Wait for mailer to complete
+
+    find_string_in_file("From: Request-log-analyzer reporter <customaddr@example.com>", @log_file).should_not be_nil
+  end
+
+  it "should allow a custom mail sender name" do
+    RequestLogAnalyzer::Controller.build(
+      :mail         => 'root@localhost',
+      :mailhost     => 'localhost:2525',
+      :mailfrom_name => 'Custom Name',
+      :source_files => log_fixture(:rails_1x),
+      :format       => RequestLogAnalyzer::FileFormat::Rails,
+      :no_progress  => true
+    ).run!
+
+    Process.wait # Wait for mailer to complete
+
+    find_string_in_file("From: Custom Name <contact@railsdoctors.com>", @log_file).should_not be_nil
+  end
+
   it "should send html mail" do
     RequestLogAnalyzer::Controller.build(
       :output       => 'HTML',


### PR DESCRIPTION
I find it useful to be able to customize the sender name and email address (for filters, etc.) that emailed reports appear to come from.  I've implemented a few simple command line options to make that easy.
