### PR TITLE
Rails3 log format - fixes syntax error while parsing parameter line with file upload

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -5,7 +5,7 @@ please add an entry to the "Not yet released" section in this document.
 
 == Not yet released
 
-* Nothing yet!
+* Fix syntax error while parsing parameter line with file upload (Michael Stark)
 
 == Request-log-analyzer 1.13 release cycle
 

--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -127,6 +127,20 @@ module RequestLogAnalyzer::FileFormat
           time_as_str.to_i
         end
       end
+
+
+      def sanitize_parameters(parameter_string)
+        parameter_string.force_encoding("UTF-8")
+          .gsub(/#</, '"')
+          .gsub(/>, \"/, '", "')
+          .gsub(/>>}/, '\""}') # #< ... >>}
+          .gsub(/>>, \"/, '\"", "') # #< ... >>, "
+          .gsub(/", @/, '\", @') # #< ... @content_type="image/jpeg", @ ... >>
+          .gsub(/="/, '=\"') # #< ... filename="IMG_2228.JPG" Content-Type: image/jpeg", ... >>
+          .gsub(/=\\", "/, '=", "') # redo "...hSMjag0w=\\",
+          .gsub(/=\\"}/, '="}') # redo "...hSMjag0w=\\"}
+          .gsub(/\\0/, '')
+      end
     end
   end
 end

--- a/spec/unit/file_format/rails3_format_spec.rb
+++ b/spec/unit/file_format/rails3_format_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe RequestLogAnalyzer::FileFormat::Rails3 do

--- a/spec/unit/file_format/rails3_format_spec.rb
+++ b/spec/unit/file_format/rails3_format_spec.rb
@@ -61,6 +61,11 @@ describe RequestLogAnalyzer::FileFormat::Rails3 do
       subject.should parse_line(line).as(:parameters).and_capture(params: { action: 'cached', controller: 'cached' })
     end
 
+    it 'parses a :parameters line with file upload correctly' do
+      line = 'Parameters: {"utf8"=>"✓", "authenticity_token"=>"eqHyMOSSzw35utH4nN+l28mRMdsHUbRxqh+hSMjag0w=", "user"=>{"photo"=>#<ActionDispatch::Http::UploadedFile:0x000000068fb190 @original_filename="IMG_2228.JPG", @content_type="image/jpeg", @headers="Content-Disposition: form-data; name=\"user[photo]\"; filename=\"IMG_2228.JPG\"\r\nContent-Type: image/jpeg\r\n", @tempfile=#<File:/tmp/RackMultipart20141010-19270-zah6b7>>}, "commit"=>"speichern"}'
+      subject.should parse_line(line).as(:parameters).and_capture(:params => {:utf8 => "\u2713", :authenticity_token => "eqHyMOSSzw35utH4nN+l28mRMdsHUbRxqh+hSMjag0w=", :user => {"photo"=>"ActionDispatch::Http::UploadedFile:0x000000068fb190 @original_filename=\"IMG_2228.JPG\", @content_type=\"image/jpeg\", @headers=\"Content-Disposition: form-data; name=\"user[photo]\"; filename=\"IMG_2228.JPG\"\r\nContent-Type: image/jpeg\r\n\", @tempfile=\"File:/tmp/RackMultipart20141010-19270-zah6b7\""}, :commit => "speichern"})
+    end
+
     it 'should parse :completed lines correctly' do
       line = 'Completed 200 OK in 170ms (Views: 78.0ms | ActiveRecord: 48.2ms)'
       subject.should parse_line(line).as(:completed).and_capture(


### PR DESCRIPTION
```
/usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/request.rb:40:in `eval': (eval):1: syntax error, unexpected tCONSTANT, expecting '}' (SyntaxError)
...90 @original_filename="IMG_2228.JPG", @content_type="image/j...
...                               ^
(eval):1: syntax error, unexpected tIDENTIFIER, expecting end-of-input
...2228.JPG", @content_type="image/jpeg", @headers="Content-Dis...
...                               ^
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/request.rb:40:in `convert_eval'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/request.rb:20:in `convert_value'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/line_definition.rb:122:in `block in convert_captured_values'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/line_definition.rb:119:in `each'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/line_definition.rb:119:in `each_with_index'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/line_definition.rb:119:in `convert_captured_values'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/request.rb:114:in `add_parsed_line'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/request.rb:145:in `<<'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:315:in `update_current_request'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:230:in `parse_line'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:187:in `parse_io_19'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:134:in `block in parse_file'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:134:in `open'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:134:in `parse_file'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:95:in `block in parse_files'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:95:in `each'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:95:in `parse_files'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/source/log_parser.rb:81:in `each_request'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/lib/request_log_analyzer/controller.rb:339:in `run!'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/gems/request-log-analyzer-1.13.1/bin/request-log-analyzer:133:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/bin/request-log-analyzer:23:in `load'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/bin/request-log-analyzer:23:in `<main>'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/bin/ruby_executable_hooks:15:in `eval'
    from /usr/local/rvm/gems/ruby-2.1.3@request-log-analyzer/bin/ruby_executable_hooks:15:in `<main>'
```
