### PR TITLE
Rescue SyntaxError when converting eval'ed parameters

### DIFF
--- a/lib/request_log_analyzer/request.rb
+++ b/lib/request_log_analyzer/request.rb
@@ -58,7 +58,7 @@ module RequestLogAnalyzer
       # Converts :eval field, which should evaluate to a hash.
       def convert_eval(value, _capture_definition)
         eval(sanitize_parameters(value)).reduce({}) { |h, (k, v)| h[k.to_sym] = v; h }
-      rescue
+      rescue StandardError, SyntaxError
         nil
       end
 


### PR DESCRIPTION
Fixes #175. @searlm @barttenbrinke 
