### PR TITLE
fix syntax error by adding gsub to remove certain string

### DIFF
--- a/lib/request_log_analyzer/request.rb
+++ b/lib/request_log_analyzer/request.rb
@@ -65,7 +65,7 @@ module RequestLogAnalyzer
       # Removes certain string sequences which would be problematic for eval.
       # TODO remove all characters not valid in ruby symbols
       def sanitize_parameters(parameter_string)
-        parameter_string.gsub(/#</, '"').gsub(/>,/, '", ').gsub(/\\0/, '')
+        parameter_string.gsub(/#</, '"').gsub(/>,/, '", ').gsub(/\\0/, '').gsub(/\\u/,'')
       end
 
       # Slow default method to parse timestamps.


### PR DESCRIPTION
``` html
/home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/request.rb:60:in `eval': (eval):1: UTF-8 mixed within ASCII-8BIT source (SyntaxError)
...\xA7ģ\xD0\xCD,ˮ\xBE\xA7Կ\xB3\u05FFۣ\xACˮ\xBE\xA7\xD1̻�...
...                               ^
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/request.rb:60:in `convert_eval'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/request.rb:17:in `convert_value'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/line_definition.rb:119:in `block in convert_captured_values'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/line_definition.rb:116:in `each'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/line_definition.rb:116:in `each_with_index'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/line_definition.rb:116:in `convert_captured_values'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/request.rb:134:in `add_parsed_line'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/request.rb:165:in `<<'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/source/log_parser.rb:310:in `update_current_request'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/source/log_parser.rb:225:in `parse_line'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/source/log_parser.rb:182:in `parse_io_19'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/source/log_parser.rb:130:in `block in parse_file'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/source/log_parser.rb:130:in `open'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/source/log_parser.rb:130:in `parse_file'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/source/log_parser.rb:76:in `each_request'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/lib/request_log_analyzer/controller.rb:334:in `run!'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/gems/request-log-analyzer-1.13.3/bin/request-log-analyzer:133:in `<top (required)>'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/bin/request-log-analyzer:23:in `load'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/bin/request-log-analyzer:23:in `<main>'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/bin/ruby_executable_hooks:15:in `eval'
    from /home/op/.rvm/gems/ruby-2.0.0-p247/bin/ruby_executable_hooks:15:in `<main>'
```
