### PR TITLE
Report on HTTP Status with descriptive string

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -9,6 +9,10 @@ please add an entry to the "Not yet released" section in this document.
 
 == Request-log-analyzer 1.13 release cycle
 
+=== Version 1.13.5
+
+* Report HTTP Status with Status String as reporting in the Rails log. For example report on "200 OK" instead of just "200"
+
 === Version 1.13.4
 
 * Catch SyntaxErrors when eval'ing lines.

--- a/lib/request_log_analyzer/file_format/rails3.rb
+++ b/lib/request_log_analyzer/file_format/rails3.rb
@@ -41,9 +41,10 @@ module RequestLogAnalyzer::FileFormat
     line_definition :completed do |line|
       line.footer = true
       line.teaser = /Completed /
-      line.regexp = /Completed (\d+)? .*in (\d+(?:\.\d+)?)ms(?:[^\(]*\(Views: (\d+(?:\.\d+)?)ms .* ActiveRecord: (\d+(?:\.\d+)?)ms.*\))?/
+      line.regexp = /Completed (\d+)? (.*)? in (\d+(?:\.\d+)?)ms(?:[^\(]*\(Views: (\d+(?:\.\d+)?)ms .* ActiveRecord: (\d+(?:\.\d+)?)ms.*\))?/
 
       line.capture(:status).as(:integer)
+      line.capture(:status_string)
       line.capture(:duration).as(:duration, unit: :msec)
       line.capture(:view).as(:duration, unit: :msec)
       line.capture(:db).as(:duration, unit: :msec)
@@ -91,7 +92,7 @@ module RequestLogAnalyzer::FileFormat
 
       analyze.frequency category: REQUEST_CATEGORIZER, title: 'Most requested'
       analyze.frequency :method, title: 'HTTP methods'
-      analyze.frequency :status, title: 'HTTP statuses returned'
+      analyze.frequency category: lambda{ |x| "#{x[:status]} #{x[:status_string]}"}, title: 'HTTP statuses returned'
 
       analyze.duration :duration, category: REQUEST_CATEGORIZER, title: 'Request duration', line_type: :completed
       analyze.duration :partial_duration, category: :rendered_file, title: 'Partials rendering time', line_type: :rendered

--- a/lib/request_log_analyzer/version.rb
+++ b/lib/request_log_analyzer/version.rb
@@ -1,3 +1,3 @@
 module RequestLogAnalyzer
-  VERSION = '1.13.5'
+  VERSION = '1.13.4'
 end

--- a/lib/request_log_analyzer/version.rb
+++ b/lib/request_log_analyzer/version.rb
@@ -1,3 +1,3 @@
 module RequestLogAnalyzer
-  VERSION = '1.13.4'
+  VERSION = '1.13.5'
 end

--- a/spec/unit/file_format/rails3_format_spec.rb
+++ b/spec/unit/file_format/rails3_format_spec.rb
@@ -70,18 +70,18 @@ describe RequestLogAnalyzer::FileFormat::Rails3 do
     it 'should parse :completed lines correctly' do
       line = 'Completed 200 OK in 170ms (Views: 78.0ms | ActiveRecord: 48.2ms)'
       subject.should parse_line(line).as(:completed).and_capture(
-          duration: 0.170, view: 0.078, db: 0.0482, status: 200)
+          duration: 0.170, view: 0.078, db: 0.0482, status: 200, status_string: "OK")
     end
 
     it 'should parse :completed lines correctly when ActiveRecord is not mentioned' do
       line = 'Completed 200 OK in 364ms (Views: 31.4ms)'
-      subject.should parse_line(line).as(:completed).and_capture(duration: 0.364, status: 200)
+      subject.should parse_line(line).as(:completed).and_capture(duration: 0.364, status: 200, status_string: "OK")
     end
 
     it 'should parse :completed lines correctly when other durations are specified' do
       line = 'Completed 200 OK in 384ms (Views: 222.0ms | ActiveRecord: 121.0ms | Sphinx: 0.0ms)'
       subject.should parse_line(line).as(:completed).and_capture(duration: 0.384, view: 0.222,
-          db: 0.121, status: 200)
+          db: 0.121, status: 200, status_string: "OK")
     end
 
     it 'should parse :routing_error lines correctly' do


### PR DESCRIPTION
Currently the report gives a frequency of "200" or "406" or whatever. Some HTTP Codes are obscure and are always a bit hard to remember. This change request ensure that they get aggregated and reported as "200 OK" or "404 Not Found" etc.
