### PR TITLE
Added support for log files that are longer than 2gb

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -5,7 +5,7 @@ please add an entry to the "Not yet released" section in this document.
 
 == Not yet released
 
-* Nothing yet!
+* Added support for log files that are longer than 2gb
 
 == Request-log-analyzer 1.13 release cycle
 

--- a/lib/request_log_analyzer/database/source.rb
+++ b/lib/request_log_analyzer/database/source.rb
@@ -4,7 +4,7 @@ class RequestLogAnalyzer::Database::Source < RequestLogAnalyzer::Database::Base
       database.connection.create_table(:sources) do |t|
         t.column :filename, :string
         t.column :mtime,    :datetime
-        t.column :filesize, :integer
+        t.column :filesize, :integer, limit: 8
       end
     end
   end


### PR DESCRIPTION
Currently, log files that are longer than 2gb throw an error when the length is attempted to be saved into the source table. This forces the data to be stored as a limit 8 integer instead of a limit 4 integer.

I couldn't get the specs working before I made any changes, but I am seeing the same failures after making the changes. These were ran using ruby 2.2.2 and I believe AR 5.0.0
